### PR TITLE
feat: add chat interface with tools and streaming

### DIFF
--- a/frontend/src/chat/Chat.tsx
+++ b/frontend/src/chat/Chat.tsx
@@ -1,0 +1,18 @@
+import ChatMessage from './ChatMessage';
+import ChatInput from './ChatInput';
+import { useChatStore } from '../state/useChatStore';
+
+export default function Chat() {
+  const messages = useChatStore((s) => s.messages);
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-auto p-4">
+        {messages.map((m) => (
+          <ChatMessage key={m.id} message={m} />
+        ))}
+      </div>
+      <ChatInput />
+    </div>
+  );
+}
+

--- a/frontend/src/chat/ChatInput.tsx
+++ b/frontend/src/chat/ChatInput.tsx
@@ -1,0 +1,44 @@
+import { useState, FormEvent } from 'react';
+import { useChatStore } from '../state/useChatStore';
+import ToolsMenu from './ToolsMenu';
+
+export default function ChatInput() {
+  const [value, setValue] = useState('');
+  const [files, setFiles] = useState<File[]>([]);
+  const send = useChatStore((s) => s.sendMessage);
+  const runCommand = useChatStore((s) => s.runCommand);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!value.trim() && files.length === 0) return;
+    if (value.startsWith('/')) {
+      await runCommand(value, files);
+    } else {
+      await send(value, files);
+    }
+    setValue('');
+    setFiles([]);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="flex items-center gap-2 p-2 border-t">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="flex-1 border rounded p-2"
+        placeholder="Type message or /command"
+      />
+      <input
+        type="file"
+        multiple
+        onChange={(e) => setFiles(Array.from(e.target.files ?? []))}
+      />
+      <ToolsMenu onSelect={(cmd) => runCommand(cmd)} />
+      <button type="submit" className="px-3 py-2 bg-blue-500 text-white rounded">
+        Send
+      </button>
+    </form>
+  );
+}
+

--- a/frontend/src/chat/ChatMessage.tsx
+++ b/frontend/src/chat/ChatMessage.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import type { ChatMessage } from '../state/useChatStore';
+import { useChatStore } from '../state/useChatStore';
+
+interface Props {
+  message: ChatMessage;
+}
+
+export default function ChatMessage({ message }: Props) {
+  const [open, setOpen] = useState(false);
+  const copy = useChatStore((s) => s.copyMessage);
+  const retry = useChatStore((s) => s.retryMessage);
+  const fork = useChatStore((s) => s.forkConversation);
+
+  return (
+    <div className="mb-4">
+      <div className="flex items-start gap-2">
+        <div className="font-bold w-20 text-right pr-2">
+          {message.role === 'user' ? 'You' : 'Assistant'}
+        </div>
+        <div className="flex-1">
+          <div className="whitespace-pre-wrap">{message.content}</div>
+          {message.attachments && message.attachments.length > 0 && (
+            <ul className="mt-2 text-sm text-blue-700">
+              {message.attachments.map((a) => (
+                <li key={a.id}>
+                  <a href={a.url} target="_blank" rel="noreferrer">
+                    {a.file.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+          {message.role === 'assistant' && (
+            <div className="mt-1 flex gap-2 text-xs">
+              <button onClick={() => copy(message.id)}>Copy</button>
+              <button onClick={() => retry(message.id)}>Retry</button>
+              <button onClick={() => fork(message.id)}>Fork</button>
+              {(message.rationale || message.toolLogs) && (
+                <button onClick={() => setOpen((o) => !o)}>
+                  {open ? 'Hide logs' : 'Show logs'}
+                </button>
+              )}
+            </div>
+          )}
+          {open && (
+            <div className="mt-2 p-2 bg-gray-100 rounded text-xs">
+              {message.rationale && (
+                <pre className="mb-2 whitespace-pre-wrap">
+                  {message.rationale}
+                </pre>
+              )}
+              {message.toolLogs && (
+                <pre className="whitespace-pre-wrap">{message.toolLogs}</pre>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/chat/ToolsMenu.tsx
+++ b/frontend/src/chat/ToolsMenu.tsx
@@ -1,0 +1,28 @@
+interface Props {
+  onSelect: (command: string) => void | Promise<void>;
+}
+
+const tools = ['crawl', 'analyze', 'schema.lint', 'content.fix'];
+
+export default function ToolsMenu({ onSelect }: Props) {
+  return (
+    <select
+      onChange={(e) => {
+        const val = e.target.value;
+        if (val) {
+          void onSelect(`/${val}`);
+          e.target.value = '';
+        }
+      }}
+      className="border rounded p-2"
+    >
+      <option value="">Tools</option>
+      {tools.map((t) => (
+        <option key={t} value={t}>
+          {t}
+        </option>
+      ))}
+    </select>
+  );
+}
+

--- a/frontend/src/chat/index.ts
+++ b/frontend/src/chat/index.ts
@@ -1,0 +1,4 @@
+export { default as Chat } from './Chat';
+export { default as ChatInput } from './ChatInput';
+export { default as ChatMessage } from './ChatMessage';
+export { default as ToolsMenu } from './ToolsMenu';

--- a/frontend/src/state/useChatStore.ts
+++ b/frontend/src/state/useChatStore.ts
@@ -1,0 +1,172 @@
+import { create } from 'zustand';
+
+export interface Attachment {
+  id: string;
+  file: File;
+  url: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  attachments?: Attachment[];
+  rationale?: string;
+  toolLogs?: string;
+  status?: 'streaming' | 'done' | 'error';
+}
+
+interface ChatState {
+  messages: ChatMessage[];
+  sendMessage: (content: string, attachments?: File[]) => Promise<void>;
+  copyMessage: (id: string) => void;
+  retryMessage: (id: string) => Promise<void>;
+  forkConversation: (id: string) => void;
+  runCommand: (command: string, attachments?: File[]) => Promise<void>;
+}
+
+async function streamResponse(
+  response: Response,
+  onChunk: (chunk: string) => void
+) {
+  const reader = response.body?.getReader();
+  const decoder = new TextDecoder();
+  if (!reader) return;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    onChunk(decoder.decode(value, { stream: true }));
+  }
+}
+
+export const useChatStore = create<ChatState>((set, get) => ({
+  messages: [],
+  async sendMessage(content, files = []) {
+    const userId = crypto.randomUUID();
+    const attachments = files.map((file) => ({
+      id: crypto.randomUUID(),
+      file,
+      url: typeof window !== 'undefined' ? URL.createObjectURL(file) : '',
+    }));
+    set((s) => ({ messages: [...s.messages, { id: userId, role: 'user', content, attachments }] }));
+
+    const assistantId = crypto.randomUUID();
+    set((s) => ({ messages: [...s.messages, { id: assistantId, role: 'assistant', content: '', status: 'streaming' }] }));
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: get().messages.map(({ role, content }) => ({ role, content })) }),
+      });
+
+      let full = '';
+      await streamResponse(res, (chunk) => {
+        full += chunk;
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.id === assistantId ? { ...m, content: full } : m
+          ),
+        }));
+      });
+
+      set((s) => ({
+        messages: s.messages.map((m) =>
+          m.id === assistantId
+            ? {
+                ...m,
+                status: 'done',
+                rationale: res.headers.get('x-rationale') || undefined,
+                toolLogs: res.headers.get('x-tool-log') || undefined,
+              }
+            : m
+        ),
+      }));
+    } catch (err) {
+      set((s) => ({
+        messages: s.messages.map((m) =>
+          m.id === assistantId
+            ? {
+                ...m,
+                status: 'error',
+                content: err instanceof Error ? err.message : String(err),
+              }
+            : m
+        ),
+      }));
+    }
+  },
+  copyMessage(id) {
+    const msg = get().messages.find((m) => m.id === id);
+    if (msg && typeof navigator !== 'undefined') {
+      void navigator.clipboard.writeText(msg.content);
+    }
+  },
+  async retryMessage(id) {
+    const msg = get().messages.find((m) => m.id === id);
+    if (msg && msg.role === 'assistant') {
+      const idx = get().messages.findIndex((m) => m.id === id);
+      const prev = get().messages[idx - 1];
+      if (prev && prev.role === 'user') {
+        await get().sendMessage(prev.content, prev.attachments?.map((a) => a.file));
+      }
+    }
+  },
+  forkConversation(id) {
+    const idx = get().messages.findIndex((m) => m.id === id);
+    if (idx >= 0) {
+      set((s) => ({ messages: s.messages.slice(0, idx + 1) }));
+    }
+  },
+  async runCommand(command, attachments = []) {
+    const [cmd, ...rest] = command.replace(/^\//, '').split(' ');
+    const input = rest.join(' ');
+    const tools = ['crawl', 'analyze', 'schema.lint', 'content.fix'];
+    if (tools.includes(cmd)) {
+      const userId = crypto.randomUUID();
+      set((s) => ({ messages: [...s.messages, { id: userId, role: 'user', content: `/${cmd} ${input}` }] }));
+      const assistantId = crypto.randomUUID();
+      set((s) => ({ messages: [...s.messages, { id: assistantId, role: 'assistant', content: '', status: 'streaming' }] }));
+      try {
+        const res = await fetch(`/api/tools/${cmd}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ input }),
+        });
+        let full = '';
+        await streamResponse(res, (chunk) => {
+          full += chunk;
+          set((s) => ({ messages: s.messages.map((m) => (m.id === assistantId ? { ...m, content: full } : m)) }));
+        });
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.id === assistantId
+              ? {
+                  ...m,
+                  status: 'done',
+                  rationale: res.headers.get('x-rationale') || undefined,
+                  toolLogs: res.headers.get('x-tool-log') || undefined,
+                }
+              : m
+          ),
+        }));
+      } catch (err) {
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.id === assistantId
+              ? {
+                  ...m,
+                  status: 'error',
+                  content: err instanceof Error ? err.message : String(err),
+                }
+              : m
+          ),
+        }));
+      }
+    } else if (cmd === 'clear') {
+      set({ messages: [] });
+    } else {
+      await get().sendMessage(command, attachments);
+    }
+  },
+}));


### PR DESCRIPTION
## Summary
- build Zustand chat store with streaming responses, attachments, copy/retry/fork actions, and backend tool invocation
- add chat UI components for messages, input, and tools menu with slash commands and collapsible rationale logs

## Testing
- `pnpm exec eslint src/chat src/state`


------
https://chatgpt.com/codex/tasks/task_e_689933d3f4f0832e805a4b9c226c057a