### PR TITLE
feat: expand history and settings pages

### DIFF
--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -1,18 +1,95 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useRunStore } from '../store/runStore';
+import type { Run } from '../shared/types';
+
+const PAGE_SIZE = 10;
 
 export default function History() {
   const runs = useRunStore((s) => s.runs);
   const loadRuns = useRunStore((s) => s.loadRuns);
-  useEffect(() => { loadRuns(); }, [loadRuns]);
+
+  const [filter, setFilter] = useState('');
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [filter, runs.length]);
+
+  const filtered = useMemo(
+    () =>
+      runs.filter((r) =>
+        r.url.toLowerCase().includes(filter.toLowerCase())
+      ),
+    [runs, filter]
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageRuns = filtered.slice(
+    page * PAGE_SIZE,
+    page * PAGE_SIZE + PAGE_SIZE
+  );
+
   return (
-    <div>
-      <h1 className="text-xl font-semibold mb-2">History</h1>
-      <ul>
-        {runs.map((r) => (
-          <li key={r.id}>{r.id} - {r.url}</li>
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">History</h1>
+      <div>
+        <label htmlFor="history-filter" className="block text-sm font-medium">
+          Filter
+        </label>
+        <input
+          id="history-filter"
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="mt-1 w-full rounded-md border border-slate-200 p-2 text-sm dark:border-slate-800 dark:bg-slate-950"
+          placeholder="Search by URL"
+        />
+      </div>
+      <ul className="divide-y divide-slate-200 dark:divide-slate-800">
+        {pageRuns.map((r: Run) => (
+          <li key={r.id} className="py-2">
+            <Link
+              to={`/runs/${r.id}`}
+              onClick={() => useRunStore.setState({ currentRun: r })}
+              className="text-blue-600 hover:underline"
+            >
+              {r.url}
+            </Link>
+            <span className="ml-2 text-xs text-slate-500">
+              {new Date(r.started_at).toLocaleString()}
+            </span>
+          </li>
         ))}
+        {pageRuns.length === 0 && (
+          <li className="py-2 text-sm text-slate-500">No runs found.</li>
+        )}
       </ul>
+      <nav className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.max(p - 1, 0))}
+          disabled={page === 0}
+          className="rounded-md border border-slate-200 px-3 py-1 text-sm disabled:opacity-50 dark:border-slate-800"
+        >
+          Previous
+        </button>
+        <span className="text-sm">
+          Page {Math.min(page + 1, totalPages)} of {totalPages}
+        </span>
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.min(p + 1, totalPages - 1))}
+          disabled={page >= totalPages - 1}
+          className="rounded-md border border-slate-200 px-3 py-1 text-sm disabled:opacity-50 dark:border-slate-800"
+        >
+          Next
+        </button>
+      </nav>
     </div>
   );
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,3 +1,157 @@
+import { useEffect, useState } from 'react';
+import { Input } from '../components/input';
+import { Button } from '../components/button';
+
+interface Prefs {
+  apiKey: string;
+  model: string;
+  engine: string;
+  theme: 'system' | 'dark';
+  telemetry: boolean;
+}
+
+const defaultPrefs: Prefs = {
+  apiKey: '',
+  model: 'gpt-4',
+  engine: 'stable',
+  theme: 'system',
+  telemetry: false,
+};
+
 export default function Settings() {
-  return <div>Settings (weights, engines, theme) coming next.</div>;
+  const [prefs, setPrefs] = useState<Prefs>(defaultPrefs);
+  const [errors, setErrors] = useState<{ apiKey?: string }>({});
+
+  useEffect(() => {
+    const stored = localStorage.getItem('settings');
+    if (stored) {
+      try {
+        setPrefs({ ...defaultPrefs, ...JSON.parse(stored) });
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('settings', JSON.stringify(prefs));
+  }, [prefs]);
+
+  useEffect(() => {
+    const dark =
+      prefs.theme === 'dark' ||
+      (prefs.theme === 'system' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  }, [prefs.theme]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value, type, checked } = e.target;
+    setPrefs((p) => ({ ...p, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs: { apiKey?: string } = {};
+    if (!prefs.apiKey.trim()) {
+      errs.apiKey = 'API key is required';
+    }
+    setErrors(errs);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <div>
+        <label htmlFor="apiKey" className="block text-sm font-medium">
+          API Key
+        </label>
+        <Input
+          id="apiKey"
+          name="apiKey"
+          type="password"
+          value={prefs.apiKey}
+          onChange={handleChange}
+          aria-describedby="apiKey-desc"
+          required
+        />
+        <p id="apiKey-desc" className="text-xs text-slate-500">
+          Key used for API calls.
+        </p>
+        {errors.apiKey && (
+          <p role="alert" className="mt-1 text-sm text-red-600">
+            {errors.apiKey}
+          </p>
+        )}
+      </div>
+      <div>
+        <label htmlFor="model" className="block text-sm font-medium">
+          Model
+        </label>
+        <select
+          id="model"
+          name="model"
+          value={prefs.model}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-md border border-slate-200 bg-white p-2 text-sm dark:border-slate-800 dark:bg-slate-950"
+        >
+          <option value="gpt-4">GPT-4</option>
+          <option value="gpt-3.5">GPT-3.5</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="engine" className="block text-sm font-medium">
+          Engine
+        </label>
+        <select
+          id="engine"
+          name="engine"
+          value={prefs.engine}
+          onChange={handleChange}
+          className="mt-1 block w-full rounded-md border border-slate-200 bg-white p-2 text-sm dark:border-slate-800 dark:bg-slate-950"
+        >
+          <option value="stable">Stable</option>
+          <option value="experimental">Experimental</option>
+        </select>
+      </div>
+      <fieldset>
+        <legend className="text-sm font-medium">Theme</legend>
+        <div className="mt-2 flex gap-4">
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="theme"
+              value="system"
+              checked={prefs.theme === 'system'}
+              onChange={handleChange}
+            />
+            <span>System</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="radio"
+              name="theme"
+              value="dark"
+              checked={prefs.theme === 'dark'}
+              onChange={handleChange}
+            />
+            <span>Dark</span>
+          </label>
+        </div>
+      </fieldset>
+      <div>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            name="telemetry"
+            checked={prefs.telemetry}
+            onChange={handleChange}
+          />
+          <span>Share anonymous telemetry</span>
+        </label>
+      </div>
+      <Button type="submit">Save</Button>
+    </form>
+  );
 }


### PR DESCRIPTION
## Summary
- add search, pagination and deep links to run history
- implement settings form for API key, model, engine, theme and telemetry with localStorage persistence

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689936396b68832e9c5533dc55f06b29