### PR TITLE
feat(frontend): add logs panel with streaming

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,15 @@
 # React + TypeScript + Vite
 
+## Logs Panel
+
+The application exposes a logs viewer under `/logs` which allows toggling between
+backend and frontend streams. Filters (level, search, time window) and scroll
+positions are preserved per tab. The view supports live tailing, pausing, and
+downloading the currently displayed logs.
+
+When backend log endpoints are unavailable, enable the mock provider by setting
+the environment variable `VITE_LOGS_MOCK=1` before running the dev server.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/frontend/src/hooks/useLogs.ts
+++ b/frontend/src/hooks/useLogs.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getLogs, getLogsStream, downloadLogs } from '../lib/api';
+
+export interface LogsQueryOptions {
+  source: string;
+  level?: string;
+  q?: string;
+  limit?: number;
+  after?: string;
+}
+
+// simple debounce hook
+function useDebounce<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+export function useLogsQuery(opts: LogsQueryOptions) {
+  const debouncedQ = useDebounce(opts.q);
+  return useQuery({
+    queryKey: ['logs', opts.source, debouncedQ, opts.level, opts.limit, opts.after],
+    queryFn: ({ signal }) =>
+      getLogs({ ...opts, q: debouncedQ, signal }),
+    placeholderData: (prev) => prev,
+  });
+}
+
+export interface LogsStreamState<T = any> {
+  logs: T[];
+  paused: boolean;
+  pause: () => void;
+  resume: () => void;
+  clear: () => void;
+}
+
+// Stream logs using EventSource with auto-retry
+export function useLogsStream<T = any>(source: string, enabled: boolean): LogsStreamState<T> {
+  const [logs, setLogs] = useState<T[]>([]);
+  const [paused, setPaused] = useState(false);
+  const pausedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let es: EventSource | undefined;
+    let timeout: number;
+    let retry = 0;
+
+    const connect = () => {
+      es = getLogsStream(source);
+      es.onmessage = (e) => {
+        if (pausedRef.current) return;
+        try {
+          setLogs((l) => [...l, JSON.parse(e.data)]);
+        } catch {
+          /* ignore */
+        }
+      };
+      es.onerror = () => {
+        es?.close();
+        const delay = Math.min(1000 * 2 ** retry, 30000);
+        retry++;
+        timeout = window.setTimeout(connect, delay);
+        // toast notifications could be triggered here
+        console.warn('log stream disconnected');
+      };
+      es.onopen = () => {
+        if (retry > 0) {
+          console.info('log stream reconnected');
+        }
+        retry = 0;
+      };
+    };
+
+    connect();
+    return () => {
+      es?.close();
+      window.clearTimeout(timeout);
+    };
+  }, [source, enabled]);
+
+  const pause = () => {
+    pausedRef.current = true;
+    setPaused(true);
+  };
+  const resume = () => {
+    pausedRef.current = false;
+    setPaused(false);
+  };
+  const clear = () => setLogs([]);
+
+  return { logs, paused, pause, resume, clear };
+}
+
+export { downloadLogs };
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import RunDetail from './pages/RunDetail';
 import History from './pages/History';
 import Settings from './pages/Settings';
 import Chat from './pages/Chat';
+import { LogsPanel } from './panels';
 
 const router = createBrowserRouter([
   {
@@ -20,7 +21,8 @@ const router = createBrowserRouter([
   { path: 'runs/:id', element: <RunDetail /> },
   { path: 'history', element: <History /> },
   { path: 'chat', element: <Chat /> },
-  { path: 'settings', element: <Settings /> }
+  { path: 'settings', element: <Settings /> },
+  { path: 'logs', element: <LogsPanel /> }
     ]
   }
 ]);

--- a/frontend/src/panels/LogsPanel.tsx
+++ b/frontend/src/panels/LogsPanel.tsx
@@ -1,0 +1,204 @@
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/tabs';
+import { DataTable, type Column } from '../components/data-table';
+import { JSONViewer } from '../components/json-viewer';
+import { Badge } from '../components/badge';
+import { useLogsQuery, useLogsStream, LogsStreamState, downloadLogs } from '../hooks/useLogs';
+
+interface LogEntry {
+  id: string;
+  ts: number;
+  level: string;
+  message: string;
+  [key: string]: any;
+}
+
+const SOURCES = ['backend', 'frontend'] as const;
+type Source = typeof SOURCES[number];
+
+interface TabState {
+  level: string;
+  q: string;
+  time: string;
+  live: boolean;
+  scroll: number;
+}
+
+export function TabPane({
+  source,
+  state,
+  update,
+  active,
+}: {
+  source: Source;
+  state: TabState;
+  update: (v: Partial<TabState>) => void;
+  active: boolean;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const query = useLogsQuery({ source, level: state.level, q: state.q, limit: 500 });
+  const stream: LogsStreamState<LogEntry> = useLogsStream(source, state.live);
+  const logs = useMemo(
+    () => [...((query.data as any)?.logs ?? []), ...stream.logs],
+    [query.data, stream.logs]
+  );
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (active && containerRef.current) {
+      containerRef.current.scrollTop = state.scroll;
+    }
+  }, [active, state.scroll]);
+
+  const onScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    update({ scroll: e.currentTarget.scrollTop });
+  };
+
+  const rowHeight = 40;
+  const containerHeight = 384; // h-96
+  const start = Math.floor(state.scroll / rowHeight);
+  const end = Math.min(logs.length, start + Math.ceil(containerHeight / rowHeight) + 5);
+  const visible = logs.slice(start, end);
+  const offsetY = start * rowHeight;
+  const totalHeight = logs.length * rowHeight;
+
+  const toggleRow = (id: string) => {
+    setExpanded((p) => ({ ...p, [id]: !p[id] }));
+  };
+
+  const columns: Column<LogEntry>[] = [
+    {
+      key: 'ts',
+      header: 'Time',
+      render: (row) => new Date(row.ts).toLocaleTimeString(),
+    },
+    {
+      key: 'level',
+      header: 'Level',
+      render: (row) => (
+        <Badge variant={row.level === 'error' ? 'destructive' : 'secondary'}>{row.level}</Badge>
+      ),
+    },
+    {
+      key: 'message',
+      header: 'Message',
+      render: (row) => (
+        <div>
+          <div
+            className="cursor-pointer" 
+            onClick={() => toggleRow(row.id)}
+          >
+            {row.message}
+          </div>
+          {expanded[row.id] && <JSONViewer data={row} className="mt-1" />}
+        </div>
+      ),
+    },
+  ];
+
+  const onDownload = () => {
+    downloadLogs({ source, level: state.level, q: state.q });
+  };
+
+  return (
+    <TabsContent value={source} className="h-full">
+      <div className="flex flex-col h-full">
+        <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 bg-white dark:bg-slate-950 p-2 border-b">
+          <select
+            className="border p-1"
+            value={state.level}
+            onChange={(e) => update({ level: e.target.value })}
+          >
+            <option value="">All</option>
+            <option value="info">info</option>
+            <option value="warn">warn</option>
+            <option value="error">error</option>
+          </select>
+          <input
+            className="border p-1 flex-1 min-w-32"
+            placeholder="search"
+            value={state.q}
+            onChange={(e) => update({ q: e.target.value })}
+          />
+          <select
+            className="border p-1"
+            value={state.time}
+            onChange={(e) => update({ time: e.target.value })}
+          >
+            <option value="1h">1h</option>
+            <option value="24h">24h</option>
+          </select>
+          <label className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={state.live}
+              onChange={(e) => update({ live: e.target.checked })}
+            />
+            Live Tail
+          </label>
+          <button
+            className="border px-2 py-1"
+            onClick={() => (stream.paused ? stream.resume() : stream.pause())}
+          >
+            {stream.paused ? 'Resume' : 'Pause'}
+          </button>
+          <button className="border px-2 py-1" onClick={() => stream.clear()}>
+            Clear View
+          </button>
+          <button className="border px-2 py-1" onClick={onDownload}>
+            Download
+          </button>
+        </div>
+        <div
+          ref={containerRef}
+          onScroll={onScroll}
+          className="relative h-96 overflow-auto"
+        >
+          <div style={{ height: totalHeight }}>
+            <div style={{ transform: `translateY(${offsetY}px)` }}>
+              <DataTable
+                columns={columns}
+                data={visible}
+                className="overflow-visible"
+                getRowKey={(row) => row.id}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </TabsContent>
+  );
+}
+
+export default function LogsPanel() {
+  const [active, setActive] = useState<Source>('backend');
+  const [state, setState] = useState<Record<Source, TabState>>({
+    backend: { level: '', q: '', time: '1h', live: false, scroll: 0 },
+    frontend: { level: '', q: '', time: '1h', live: false, scroll: 0 },
+  });
+
+  const update = (source: Source, v: Partial<TabState>) =>
+    setState((s) => ({ ...s, [source]: { ...s[source], ...v } }));
+
+  return (
+    <Tabs value={active} onValueChange={(v) => setActive(v as Source)} className="h-full">
+      <TabsList>
+        {SOURCES.map((s) => (
+          <TabsTrigger key={s} value={s} className="capitalize">
+            {s}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {SOURCES.map((s) => (
+        <TabPane
+          key={s}
+          source={s}
+          state={state[s]}
+          update={(v) => update(s, v)}
+          active={active === s}
+        />
+      ))}
+    </Tabs>
+  );
+}
+

--- a/frontend/src/panels/index.ts
+++ b/frontend/src/panels/index.ts
@@ -1,1 +1,2 @@
 export { default as EvidencePanel } from './EvidencePanel';
+export { default as LogsPanel } from './LogsPanel';

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -43,6 +43,7 @@ export default function AppShell() {
           <Link className="block hover:underline" to="/">Dashboard</Link>
           <Link className="block hover:underline" to="/history">History</Link>
           <Link className="block hover:underline" to="/settings">Settings</Link>
+          <Link className="block hover:underline" to="/logs">Logs</Link>
         </nav>
       </aside>
       <header className="flex items-center gap-2 px-4 border-b border-neutral-800">

--- a/frontend/src/tests/logsPanel.virtualization.test.tsx
+++ b/frontend/src/tests/logsPanel.virtualization.test.tsx
@@ -1,0 +1,34 @@
+const logs = Array.from({ length: 1000 }, (_, i) => ({
+  id: String(i),
+  ts: i,
+  level: 'info',
+  message: `msg ${i}`,
+}));
+
+vi.mock('../hooks/useLogs', () => ({
+  useLogsQuery: () => ({ data: { logs } }),
+  useLogsStream: () => ({ logs: [], paused: false, pause: vi.fn(), resume: vi.fn(), clear: vi.fn() }),
+  downloadLogs: vi.fn(),
+}));
+
+import { render } from '@testing-library/react';
+import { TabPane } from '../panels/LogsPanel';
+import { Tabs } from '../components/tabs';
+
+describe('LogsPanel virtualization', () => {
+  it('renders only visible rows', () => {
+    const { container } = render(
+      <Tabs value="backend">
+        <TabPane
+          source="backend"
+          state={{ level: '', q: '', time: '1h', live: false, scroll: 0 }}
+          update={() => {}}
+          active
+        />
+      </Tabs>
+    );
+
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows.length).toBeLessThan(logs.length);
+  });
+});

--- a/frontend/src/tests/useLogsQuery.test.tsx
+++ b/frontend/src/tests/useLogsQuery.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useLogsQuery } from '../hooks/useLogs';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const client = new QueryClient();
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+describe('useLogsQuery', () => {
+  it('debounces search and handles paging', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ logs: [] }),
+    });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    const { rerender } = renderHook(
+      (props) => useLogsQuery(props),
+      {
+        initialProps: { source: 'backend', q: 'a' },
+        wrapper,
+      }
+    );
+    act(() => {
+      rerender({ source: 'backend', q: 'ab' });
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1][0]).toContain('q=ab');
+
+    act(() => {
+      rerender({ source: 'backend', q: 'ab', after: '42' });
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    expect(fetchMock.mock.calls[2][0]).toContain('after=42');
+  });
+});

--- a/frontend/src/tests/useLogsStream.test.tsx
+++ b/frontend/src/tests/useLogsStream.test.tsx
@@ -1,0 +1,41 @@
+const instances: MockEventSource[] = [];
+
+class MockEventSource {
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+  constructor() {
+    instances.push(this);
+  }
+  emit(data: any) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+  close() {}
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() { return false; }
+  readyState = 1;
+  url = '';
+  withCredentials = false;
+}
+
+vi.mock('../lib/api', () => ({
+  getLogsStream: () => new MockEventSource(),
+}));
+
+import { renderHook, act } from '@testing-library/react';
+import { useLogsStream } from '../hooks/useLogs';
+
+describe('useLogsStream', () => {
+  it('pauses and resumes stream', () => {
+    const { result } = renderHook(() => useLogsStream('backend', true));
+    act(() => instances[0].emit({ id: '1', ts: 0, level: 'info', message: 'a' }));
+    expect(result.current.logs.length).toBe(1);
+    act(() => result.current.pause());
+    act(() => instances[0].emit({ id: '2', ts: 1, level: 'info', message: 'b' }));
+    expect(result.current.logs.length).toBe(1);
+    act(() => result.current.resume());
+    act(() => instances[0].emit({ id: '3', ts: 2, level: 'info', message: 'c' }));
+    expect(result.current.logs.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add backend/frontend Logs panel with virtualization and live controls
- provide hooks and API helpers for querying and streaming logs
- cover new functionality with unit tests and documentation

## Testing
- `cd frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4a49ad28832eb576df3137a10aa4