### PR TITLE
feat: expose log endpoints and ring buffer

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend API
+
+This backend exposes endpoints for SEO tools and runtime log access.
+
+## Logging
+
+- `GET /logs` – return a `LogPage` of stored log entries.
+- `GET /logs/stream` – Server‑sent events stream of log entries with periodic heartbeats.
+- `GET /logs/download` – download log entries as NDJSON within a time range.
+- `POST /logs/ingest/frontend` – ingest logs from the frontend (API‑key protected).
+- `GET /healthz/logs` – report ring buffer size and ingestion lag.
+
+Query parameters and models are documented in the OpenAPI schema.

--- a/backend/mcp_server/api_server.py
+++ b/backend/mcp_server/api_server.py
@@ -1,12 +1,75 @@
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
-from .seo_astro_analyzer_server import get_title_meta, get_robots_canonical, get_headings, get_images_alt, get_links, get_structured_data, get_open_graph_twitter, get_wordcount_keywords, get_favicon_apple, get_lang_charset, get_sitemap_robots, url_to_slug
+import asyncio
+import json
 import logging
+import os
+import sqlite3
+import time
+from datetime import datetime
+from typing import Optional
+
+from fastapi import FastAPI, Header, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from .logs import (
+    LogLevel,
+    LogPage,
+    get_page,
+    log_buffer,
+    redact_metadata,
+    subscribe,
+    unsubscribe,
+    frontend_last_ingest,
+)
+from .seo_astro_analyzer_server import (
+    get_favicon_apple,
+    get_headings,
+    get_images_alt,
+    get_lang_charset,
+    get_links,
+    get_open_graph_twitter,
+    get_robots_canonical,
+    get_sitemap_robots,
+    get_structured_data,
+    get_title_meta,
+    get_wordcount_keywords,
+    url_to_slug,
+)
+
+APP_ORIGIN = os.environ.get("APP_ORIGIN", "*")
+RATE_LIMIT = int(os.environ.get("RATE_LIMIT", "100"))
+RATE_WINDOW = int(os.environ.get("RATE_WINDOW", "60"))
+HEARTBEAT = 15
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[APP_ORIGIN],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
-# Map tool names to functions
-tool_map = {
+# --- rate limiting -----------------------------------------------------------
+_req_counts = {}
+
+
+@app.middleware("http")
+async def rate_limiter(request: Request, call_next):
+    ip = request.client.host if request.client else "anon"
+    now = time.time()
+    window_start, count = _req_counts.get(ip, (now, 0))
+    if now - window_start > RATE_WINDOW:
+        window_start, count = now, 0
+    if count >= RATE_LIMIT:
+        return JSONResponse({"error": "Too Many Requests"}, status_code=429)
+    _req_counts[ip] = (window_start, count + 1)
+    return await call_next(request)
+
+
+# --- SEO analyzer endpoint ---------------------------------------------------
+
+TOOL_MAP = {
     "title_meta": get_title_meta,
     "robots_canonical": get_robots_canonical,
     "headings": get_headings,
@@ -20,6 +83,7 @@ tool_map = {
     "sitemap_robots": get_sitemap_robots,
 }
 
+
 @app.post("/api/analyze")
 async def analyze(request: Request):
     try:
@@ -27,23 +91,140 @@ async def analyze(request: Request):
         url = data.get("url")
         tools = data.get("tools", [])
         engines = data.get("engines", [])
-        logging.info(f"/api/analyze called: url={url}, tools={tools}, engines={engines}")
+        logging.info(
+            f"/api/analyze called: url={url}, tools={tools}, engines={engines}"
+        )
         if not url or not tools:
             return JSONResponse({"error": "Missing url or tools"}, status_code=400)
         results = []
         for tool in tools:
-            func = tool_map.get(tool)
+            func = TOOL_MAP.get(tool)
             if not func:
                 results.append({"tool": tool, "error": "Tool not found"})
                 continue
             try:
                 result = func(url)
                 results.append({"tool": tool, "result": result})
-            except Exception as e:
+            except Exception as e:  # pragma: no cover - defensive
                 logging.exception(f"Error running tool {tool} on {url}: {e}")
                 results.append({"tool": tool, "error": str(e)})
         run_id = url_to_slug(url)
         return {"run_id": run_id, "results": results}
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - defensive
         logging.exception(f"/api/analyze failed: {e}")
         return JSONResponse({"error": str(e)}, status_code=500)
+
+
+# --- log querying ------------------------------------------------------------
+
+@app.get("/logs", response_model=LogPage)
+def read_logs(
+    source: Optional[str] = None,
+    level: Optional[LogLevel] = None,
+    q: Optional[str] = None,
+    limit: int = 100,
+    after: Optional[int] = None,
+):
+    return get_page(source=source, level=level, q=q, limit=limit, after=after)
+
+
+@app.get("/logs/stream")
+async def stream_logs(after: Optional[int] = None):
+    async def event_generator():
+        q = subscribe()
+        try:
+            if after:
+                page = get_page(after=after)
+                for entry in page.items:
+                    yield f"data: {entry.model_dump_json()}\n\n"
+            yield ":heartbeat\n\n"
+            while True:
+                try:
+                    item = await asyncio.wait_for(q.get(), timeout=HEARTBEAT)
+                except asyncio.TimeoutError:
+                    yield ":heartbeat\n\n"
+                    continue
+                if isinstance(item, dict) and item.get("warning"):
+                    yield "event: warning\ndata: queue full\n\n"
+                else:
+                    yield f"data: {item.model_dump_json()}\n\n"
+        finally:
+            unsubscribe(q)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
+@app.get("/logs/download")
+async def download_logs(
+    source: Optional[str] = None,
+    level: Optional[LogLevel] = None,
+    q: Optional[str] = None,
+    from_: datetime = Query(..., alias="from"),
+    to: datetime = Query(..., alias="to"),
+):
+    def iter_lines():
+        page = get_page(source=source, level=level, q=q, limit=0)
+        for entry in page.items:
+            if from_ <= entry.ts <= to:
+                yield entry.model_dump_json() + "\n"
+
+    return StreamingResponse(iter_lines(), media_type="application/x-ndjson")
+
+
+# --- ingestion from frontend -------------------------------------------------
+
+FRONTEND_API_KEY = os.environ.get("FRONTEND_LOG_API_KEY")
+_db_path = os.environ.get("FRONTEND_LOG_DB", "frontend_logs.db")
+_conn = sqlite3.connect(_db_path, check_same_thread=False)
+_conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS frontend_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts TEXT,
+        level TEXT,
+        source TEXT,
+        msg TEXT,
+        metadata TEXT
+    )
+    """
+)
+_conn.commit()
+
+
+@app.post("/logs/ingest/frontend")
+async def ingest_frontend(
+    request: Request,
+    api_key: Optional[str] = Header(None, alias="X-API-Key"),
+):
+    if FRONTEND_API_KEY and api_key != FRONTEND_API_KEY:
+        raise HTTPException(status_code=401, detail="invalid api key")
+    data = await request.json()
+    level = data.get("level", "INFO").upper()
+    msg = data.get("msg", "")
+    source = data.get("source")
+    metadata = redact_metadata(data.get("metadata"))
+    ts = datetime.utcnow().isoformat()
+    _conn.execute(
+        "INSERT INTO frontend_logs (ts, level, source, msg, metadata) VALUES (?,?,?,?,?)",
+        (ts, level, source, msg, json.dumps(metadata)),
+    )
+    _conn.commit()
+    from . import logs as _logs
+
+    _logs.frontend_last_ingest = datetime.utcnow()
+    logging.log(
+        getattr(logging, level, logging.INFO),
+        msg,
+        extra={"metadata": metadata, "source": source},
+    )
+    return {"status": "ok"}
+
+
+# --- health ------------------------------------------------------------------
+
+@app.get("/healthz/logs")
+def health_logs():
+    lag = None
+    if frontend_last_ingest:
+        lag = (datetime.utcnow() - frontend_last_ingest).total_seconds()
+    return {"ring_buffer": len(log_buffer), "ingest_lag": lag}

--- a/backend/mcp_server/logs.py
+++ b/backend/mcp_server/logs.py
@@ -1,0 +1,154 @@
+import asyncio
+import logging
+from collections import deque
+from datetime import datetime
+from enum import Enum
+from itertools import count
+from typing import Any, Deque, Dict, Iterable, List, Optional, Set
+
+from pydantic import BaseModel
+
+# --- Models -----------------------------------------------------------------
+
+class LogLevel(str, Enum):
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+class LogEntry(BaseModel):
+    id: int
+    ts: datetime
+    level: LogLevel
+    msg: str
+    source: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class LogPage(BaseModel):
+    items: List[LogEntry]
+    next: Optional[int] = None
+
+
+# --- Ring buffer -------------------------------------------------------------
+
+BUFFER_SIZE = 50_000
+_stream_queue_size = int(__import__("os").environ.get("LOG_STREAM_QUEUE", "100"))
+
+log_buffer: Deque[LogEntry] = deque(maxlen=BUFFER_SIZE)
+log_id = count(1)
+
+subscribers: Set[asyncio.Queue] = set()
+frontend_last_ingest: Optional[datetime] = None
+
+SENSITIVE_KEYS = {
+    "password",
+    "token",
+    "secret",
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "set-cookie",
+}
+
+
+def redact_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if metadata is None:
+        return None
+    redacted: Dict[str, Any] = {}
+    for k, v in metadata.items():
+        if any(s in k.lower() for s in SENSITIVE_KEYS):
+            redacted[k] = "***REDACTED***"
+        else:
+            redacted[k] = v
+    return redacted
+
+
+class RingBufferHandler(logging.Handler):
+    """Logging handler that stores records in a ring buffer and mirrors output."""
+
+    def __init__(self, mirror_handlers: Iterable[logging.Handler]):
+        super().__init__()
+        self.mirror_handlers = list(mirror_handlers)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            metadata = getattr(record, "metadata", None)
+            entry = LogEntry(
+                id=next(log_id),
+                ts=datetime.fromtimestamp(record.created),
+                level=LogLevel(record.levelname.upper()),
+                msg=record.getMessage(),
+                source=record.name,
+                metadata=redact_metadata(metadata),
+            )
+            log_buffer.append(entry)
+            for q in list(subscribers):
+                try:
+                    q.put_nowait(entry)
+                except asyncio.QueueFull:
+                    while not q.empty():
+                        try:
+                            q.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
+                    try:
+                        q.put_nowait({"warning": "queue full"})
+                    except asyncio.QueueFull:
+                        pass
+            for h in self.mirror_handlers:
+                h.handle(record)
+        except Exception:
+            self.handleError(record)
+
+
+# Install handler
+root_logger = logging.getLogger()
+if not any(isinstance(h, RingBufferHandler) for h in root_logger.handlers):
+    existing = root_logger.handlers[:]
+    handler = RingBufferHandler(existing or [logging.StreamHandler()])
+    root_logger.handlers = [handler]
+    root_logger.setLevel(logging.INFO)
+
+
+# --- Query helpers -----------------------------------------------------------
+
+def get_page(
+    *,
+    source: Optional[str] = None,
+    level: Optional[LogLevel] = None,
+    q: Optional[str] = None,
+    limit: int = 100,
+    after: Optional[int] = None,
+) -> LogPage:
+    items = []
+    for entry in log_buffer:
+        if after is not None and entry.id <= after:
+            continue
+        if source and entry.source != source:
+            continue
+        if level and logging.getLevelName(entry.level.value) < logging.getLevelName(level.value):
+            continue
+        if q and q.lower() not in entry.msg.lower():
+            continue
+        items.append(entry)
+    if limit:
+        items = items[-limit:]
+    next_id = items[-1].id if items else after
+    return LogPage(items=items, next=next_id)
+
+
+# --- Subscription helpers ----------------------------------------------------
+
+
+def subscribe() -> asyncio.Queue:
+    q: asyncio.Queue = asyncio.Queue(maxsize=_stream_queue_size)
+    subscribers.add(q)
+    return q
+
+
+def unsubscribe(q: asyncio.Queue) -> None:
+    subscribers.discard(q)

--- a/backend/mcp_server/tests/test_logs.py
+++ b/backend/mcp_server/tests/test_logs.py
@@ -1,0 +1,79 @@
+import json
+import logging
+import time
+import json
+import logging
+from datetime import datetime
+from itertools import count
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from backend.mcp_server import api_server, logs
+
+
+@pytest.fixture(autouse=True)
+def reset_logs(monkeypatch):
+    logs.log_buffer.clear()
+    logs.subscribers.clear()
+    monkeypatch.setattr(logs, "log_id", count(1))
+    yield
+
+
+def test_pagination_and_after():
+    client = TestClient(api_server.app)
+    logger = logging.getLogger("test1")
+    logger.info("first")
+    logger.info("second")
+    page = client.get("/logs", params={"limit": 1, "source": "test1"}).json()
+    assert [e["msg"] for e in page["items"]] == ["second"]
+    after = page["items"][0]["id"]
+    logger.info("third")
+    page2 = client.get("/logs", params={"after": after, "source": "test1"}).json()
+    assert [e["msg"] for e in page2["items"]] == ["third"]
+
+
+def test_level_and_search_filters():
+    client = TestClient(api_server.app)
+    logger = logging.getLogger("test2")
+    logger.warning("warn special")
+    logger.error("error other")
+    page = client.get("/logs", params={"level": "ERROR", "source": "test2"}).json()
+    assert [e["msg"] for e in page["items"]] == ["error other"]
+    page2 = client.get("/logs", params={"q": "special", "source": "test2"}).json()
+    assert [e["msg"] for e in page2["items"]] == ["warn special"]
+
+
+
+
+def test_download_range():
+    client = TestClient(api_server.app)
+    logging.info("first")
+    t_from = datetime.utcnow().isoformat()
+    logging.info("second")
+    t_to = datetime.utcnow().isoformat()
+    logging.info("third")
+    resp = client.get(
+        "/logs/download",
+        params={"from": t_from, "to": t_to},
+    )
+    lines = [l for l in resp.text.strip().splitlines() if l]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["msg"] == "second"
+
+
+def test_redaction():
+    client = TestClient(api_server.app)
+    logging.info(
+        "token test", extra={"metadata": {"token": "secret", "safe": "ok"}}
+    )
+    page = client.get("/logs").json()
+    meta = page["items"][0]["metadata"]
+    assert meta["token"] == "***REDACTED***"
+    assert meta["safe"] == "ok"


### PR DESCRIPTION
## Summary
- add in-memory ring buffer with Pydantic log models
- expose `/logs`, `/logs/stream`, `/logs/download`, `/logs/ingest/frontend` and `/healthz/logs`
- document logging endpoints and add regression tests

## Testing
- `pytest backend/mcp_server/tests/test_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4a4cff98832e99938bc7944bcc5a